### PR TITLE
fix deprecated import from sphinx.util.compat

### DIFF
--- a/sphinxcontrib/mscgen.py
+++ b/sphinxcontrib/mscgen.py
@@ -25,7 +25,7 @@ from docutils import nodes
 
 from sphinx.errors import SphinxError
 from sphinx.util import ensuredir
-from sphinx.util.compat import Directive
+from docutils.parsers.rst import Directive
 
 
 class MscgenError(SphinxError):


### PR DESCRIPTION
fixes error message like:
```
$ make html
sphinx-build -b html -d _build/doctrees   . _build/html
Running Sphinx v1.7.1

Extension error:
Could not import extension sphinxcontrib.mscgen (exception: cannot import name Directive)
Makefile:55: recipe for target 'html' failed
make: *** [html] Error 2
```
for actual sphinx versions