### PR TITLE
mscgen: fix for missing errno import

### DIFF
--- a/sphinxcontrib/mscgen.py
+++ b/sphinxcontrib/mscgen.py
@@ -12,6 +12,7 @@
     :license: BOLA, see LICENSE for details.
 """
 
+import errno
 import sys
 import posixpath
 from os import path


### PR DESCRIPTION
Exceptions are not handled correctly becuase of missing errno import