### PR TITLE
mscgen: flag extension as parallel-safe

### DIFF
--- a/sphinxcontrib/mscgen.py
+++ b/sphinxcontrib/mscgen.py
@@ -220,3 +220,7 @@ def setup(app):
     app.add_config_value('mscgen_epstopdf', 'epstopdf', 'html')
     app.add_config_value('mscgen_epstopdf_args', [], 'html')
 
+    return {
+        'parallel_read_safe': True,
+        'parallel_write_safe': True,
+    }


### PR DESCRIPTION
Extension is read and write parallel safe. This allows using
parallelization options in Sphinx (-j option).