### PR TITLE
mscgen: fix latex pdf output

### DIFF
--- a/sphinxcontrib/mscgen.py
+++ b/sphinxcontrib/mscgen.py
@@ -123,18 +123,13 @@ def render_msc(self, code, format, prefix='mscgen'):
     hashkey = (code + str(self.builder.config.mscgen_args)).encode('utf-8')
     id = sha(hashkey).hexdigest()
     fname = '%s-%s.%s' % (prefix, id, format)
-    if hasattr(self.builder, 'imgpath'):
-        # HTML
-        relfn = posixpath.join(self.builder.imgpath, fname)
-        outfn = path.join(self.builder.outdir, '_images', fname)
-        tmpfn = outfn
-        mapfn = outfn + '.map'
-    else:
-        # LaTeX
-        relfn = fname
-        outfn = path.join(self.builder.outdir, fname)
+    relfn = posixpath.join(self.builder.imgpath, fname)
+    outfn = path.join(self.builder.outdir, relfn)
+    tmpfn = outfn
+
+    if format == 'pdf':
+        tmpfn = outfn[:-3] + '.eps'
         format = 'eps'
-        tmpfn = outfn[:-3] + format
 
     if path.isfile(outfn):
         return relfn, outfn, id
@@ -155,7 +150,7 @@ def render_msc(self, code, format, prefix='mscgen'):
         return None, None, None
 
     if format == 'png':
-        mscgen_args = mscgen_args[:-4] + ['-T', 'ismap', '-o', mapfn]
+        mscgen_args = mscgen_args[:-4] + ['-T', 'ismap', '-o', outfn + '.map']
         if not run_cmd(self.builder, mscgen_args, 'mscgen', 'mscgen', code):
             return None, None, None
     else:  # PDF/EPS


### PR DESCRIPTION
Since 2014 all builders have had the `imgpath` property, resulting in the `if hasattr(self.builder, 'imgpath'):` check being invalid. https://github.com/sphinx-doc/sphinx/commit/1e63f34d2eb553262ba068e1a21a29f022a7b9e4

Place outputs in the same location regardless of the output format, and use the `format` variable directly when determing whether we need to go through the intermediate `.eps` file format.